### PR TITLE
bridge: add

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ const render = require('virtual-dom/create-element')
 const sheetRouter = require('sheet-router')
 const h = require('virtual-dom/h')
 
-const router = sheetRouter(function (route) {
+const router = sheetRouter(function (r, t) {
   return [
-    route('/foo/bar', function (params, h, state) {
+    r('/foo/bar', function (params, h, state) {
       h('div', null, 'hello world')
     }
   ]
@@ -141,9 +141,9 @@ const sheetRouter = require('sheet-router')
 const render = require('react-dom')
 const react = require('react')
 
-const router = sheetRouter(function (route) {
+const router = sheetRouter(function (r, t) {
   return [
-    route('/foo/bar', function (params, h, state) {
+    r('/foo/bar', function (params, h, state) {
       h('div', null, 'hello world')
     }
   ]
@@ -170,6 +170,22 @@ that are then passed to the matched routes. Cleans urls to only match the
 ### history(cb(href))
 Call a callback to handle html5 pushsState history and handle `<a href="">`
 clicks.
+
+### bridge(render, stateKey?, router(state))
+Bridge a render function that passes a state object to sheet-router.
+sheet-router is then wrapped in a thunk, and will only diff paths if the route
+on the state object has changed. This requires routes to return a thunk which
+takes additional arguments, which can be done by calling the second argument of
+`t` (for thunk) instead of `r` to create routes.
+```js
+const bridge = require('sheet-router/bridge')
+const sheetRouter = require('sheet-router')
+const createApp = require('virtual-app')
+
+const app = createApp(document.body, vdom)
+const render = app.start(modifyState, initialState)
+bridge(render, (state) => router(state.location, app.h))
+```
 
 ## See Also
 - [wayfarer][12]

--- a/bridge.js
+++ b/bridge.js
@@ -1,0 +1,29 @@
+const assert = require('assert')
+
+module.exports = bridge
+
+// create a thunk bridge between a router and a render function
+// (fn, str?, fn) -> null
+function bridge (render, key, cb) {
+  if (!cb) {
+    cb = key
+    key = 'location'
+  }
+
+  assert.equal(typeof render, 'function', 'render must be a function')
+  assert.equal(typeof key, 'string', 'key must be a function')
+  assert.equal(typeof cb, 'function', 'cb must be a function')
+
+  var currLocation = null
+  var currElement = null
+
+  render(function (state) {
+    if (currElement && state[key] === currLocation) {
+      return currElement(state)
+    } else {
+      currElement = cb(state)
+      currLocation = state[key]
+      return currElement(state)
+    }
+  })
+}

--- a/index.js
+++ b/index.js
@@ -16,12 +16,25 @@ function sheetRouter (dft, createTree) {
   assert.equal(typeof createTree, 'function', 'createTree must be a function')
 
   const router = wayfarer(dft)
-  var tree = createTree(function (route, child) {
+  var tree = createTree(r, t)
+
+  // register regular route
+  function r (route, child) {
     assert.equal(typeof route, 'string', 'route must be a string')
     assert.ok(child, 'child exists')
     route = route.replace(/^\//, '')
     return [ route, child ]
-  })
+  }
+
+  // register thunked route
+  function t (route, child) {
+    return r(route, function () {
+      const args = sliced(arguments)
+      return function router_thunk () {
+        return child.apply(null, args.concat(sliced(arguments)))
+      }
+    })
+  }
 
   tree = Array.isArray(tree) ? tree : [ tree ]
 


### PR DESCRIPTION
Add a `bridge` between a functional router and `sheet-router`. Has a lil bit of indirection / will be slightly slower than a custom method; but generally fast enough I reckon. Makes it so:
- the router can be `bridge`d to a state thing
- on re-render if the path is the same, no match occurs and the same element is simply returned from mem rather than matching the routes again