### PR TITLE
Add failing test

### DIFF
--- a/test.js
+++ b/test.js
@@ -158,3 +158,22 @@ test('should route partial cojoined paths 3 levels deep', function (t) {
 
   router('/foo/baz/ban/bar')
 })
+
+test('should route multiple nested paths 2 levels deep', function (t) {
+  t.plan(2)
+  const router = sheetRouter(function (route) {
+    return [
+      route('/foo', [
+        route('/bar', function () {
+          t.pass('called')
+        }),
+        route('/baz', function () {
+          t.pass('called')
+        })
+      ])
+    ]
+  })
+
+  router('/foo/bar')
+  router('/foo/baz')
+})


### PR DESCRIPTION
Multiple nested paths on same level seems to throw an error.

I'm now sure how to fix but I ran into this today while converting editdata.org to use `sheet-router`.