### PR TITLE
add herf.js to npm package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "index.js",
     "history.js",
     "bridge.js",
+    "href.js",
     "bin/*"
   ]
 }


### PR DESCRIPTION
`href.js` is missing from the `files` list of package.json, will cause error when require.

```
 Cannot find module 'sheet-router/href'
```