### PR TITLE
Fix documentation error for nested views

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,11 @@ content based on the url, we could declare a view called `base.js` using
 [virtual-dom][13].
 ```js
 module.exports = function (content) {
-  return function (params, h, state) {
-    return h('main', [
-      h('header'),
-      h('aside'),
-      content(params, h, state)
-    ])
-  }
+  return h('main', [
+    h('header'),
+    h('aside'),
+    content(params, h, state)
+  ])
 }
 ```
 


### PR DESCRIPTION
The wrapper fn is provided in the routes in the code block immediately following the `base.js` definition.

I prefer defining that wrapper in the routes, so i changed this code block rather than the routes definition code block. If you'd rather it be the other way, nbd – I can swap it.