### PR TITLE
Addresses issue #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const hash = require('sheet-router/hash')
 const match = require('hash-match')
 hash(function (href) {
   router(match(href))
-  console.log('hash location changed: ', + href)
+  console.log('hash location changed: ' + href)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ history(function (href) {
 })
 ```
 
+### hash
+Interacting with hash changes is often a common fallback scenario for those who don't have support for browser history. Whenever a `hashchange` event is triggered, sheet-router will trigger an update as seen below. However in order to match hash prefixed routes, the `hash-match` module can be used to normalize routes (ex: `#/foo` becomes `/foo`).
+```js
+const hash = require('sheet-router/hash')
+const match = require('hash-match')
+hash(function (href) {
+  router(match(href))
+  console.log('hash location changed: ', + href)
+})
+```
+
 ### href
 In HTML links are represented with `<a href="">` style tags. Sheet-router can
 be smart about these and handle them globally. This way there's no need to

--- a/hash.js
+++ b/hash.js
@@ -3,6 +3,9 @@ const assert = require('assert')
 
 module.exports = hash
 
+// listen to window hashchange events
+// and update router accordingly
+// fn(cb) -> null
 function hash (cb) {
   assert.equal(typeof cb, 'function', 'cb must be a function')
   window.onhashchange = function (e) {

--- a/hash.js
+++ b/hash.js
@@ -1,0 +1,11 @@
+const window = require('global/window')
+const assert = require('assert')
+
+module.exports = hash
+
+function hash (cb) {
+  assert.equal(typeof cb, 'function', 'cb must be a function')
+  window.onhashchange = function (e) {
+    cb(window.location.hash)
+  }
+}


### PR DESCRIPTION
In theory it should work as proposed, you provide a function that listens for hash change events and the user can install a module like `hash-match` to normalize the route so it matches a predefined route correctly. I think I provided a decent explanation on the README but feel free to adjust it as you see fit.