### PR TITLE
test: createRoute

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,13 @@ render(router('/foo', react.createElement, { name: 'Jane' }), document.body)
 ```
 
 ## API
-### router = sheetRouter(dft?, createTree(route))
+### router = sheetRouter(dft?, createTree(route), createRoute?)
 Create a new router from a nested array. Takes an optional default path as the
 first argument.
+
+If `createRoute(route)` is passed as the third argument, the `route()` function
+passed to `createTree()` can be manipulated. This is useful for things like
+changing argument order and the like.
 
 ### router(route, [,...])
 Match a route on the router. Takes a path and an arbitrary list of arguments
@@ -143,6 +147,7 @@ Call a callback to handle `<a href="#">` clicks.
 ## See Also
 - [wayfarer][12]
 - [hyperx][14]
+- [choo](https://github.com/yoshuawuyts/choo)
 
 ## License
 [MIT](https://tldrlegal.com/license/mit-license)

--- a/index.js
+++ b/index.js
@@ -7,14 +7,16 @@ module.exports = sheetRouter
 // Fast, modular client router
 // fn(str, any[..], fn?) -> fn(str, any[..])
 function sheetRouter (dft, createTree, createRoute) {
-  createRoute = createRoute ? createRoute(r) : r
+  createRoute = (createRoute ? createRoute(_createRoute) : _createRoute)
+
   if (!createTree) {
     createTree = dft
     dft = ''
   }
 
-  assert.equal(typeof dft, 'string', 'dft must be a string')
-  assert.equal(typeof createTree, 'function', 'createTree must be a function')
+  assert.equal(typeof dft, 'string', 'sheet-router: dft must be a string')
+  assert.equal(typeof createTree, 'function', 'sheet-router: createTree must be a function')
+  assert.equal(typeof createRoute, 'function', 'sheet-router: createRoute must be a function')
 
   const router = wayfarer(dft)
   const tree = createTree(createRoute)
@@ -55,7 +57,7 @@ function sheetRouter (dft, createTree, createRoute) {
 }
 
 // register regular route
-function r (route, inline, child) {
+function _createRoute (route, inline, child) {
   if (!child) {
     child = inline
     inline = null

--- a/test.js
+++ b/test.js
@@ -179,3 +179,37 @@ test('should allow for default routes using three args', function (t) {
   router('/foo')
   router('/foo/bar')
 })
+
+test('should allow for a custom createRoute function', function (t) {
+  t.plan(2)
+  const router = sheetRouter('', (route) => {
+    return [
+      route('/foo/:bin', (state, send) => {
+        const expected = {
+          foo: 'bar',
+          params: { bin: 'baz' }
+        }
+        t.deepEqual(state, expected, 'state was merged')
+        t.equal(send, 'oi')
+      })
+    ]
+  }, createRoute)
+
+  router('/foo/baz', { foo: 'bar' })
+
+  function createRoute (routeFn) {
+    return function (route, inline, child) {
+      if (!child) inline = wrap(inline)
+      else child = wrap(child)
+      return routeFn(route, inline, child)
+    }
+
+    function wrap (child) {
+      const send = 'oi'
+      return function wrap (params, state) {
+        state.params = params
+        return child(state, send)
+      }
+    }
+  }
+})


### PR DESCRIPTION
Add tests for `createRoute()`; made internal naming a bit more clear (':