### PR TITLE
Support filtering DOM nodes that will be processed in href()

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ href(function (href) {
 })
 ```
 
+Often it is useful to filter the urls that the `href()` callback will be called with. You can do this by providing a second parameter containing a filtering function.
+
+For example, if we wanted to filter out all link clicks that have been tagged with a data attribute `data-external-link` we could do it like this:
+
+```js
+const href = require('sheet-router/href')
+href(function (url) {
+  router(url)
+  console.log('link was clicked: ' + url)
+}, allowInternalLinks)
+
+function allowInternalLinks(node) {
+  const isExternalLink = node.hasAttribute('data-external-link')
+  return !isExternalLink
+}
+```
+
 ### virtual-dom example
 ```js
 const render = require('virtual-dom/create-element')
@@ -141,7 +158,7 @@ that are then passed to the matched routes. Cleans urls to only match the
 ### history(cb(href))
 Call a callback to handle html5 pushsState history.
 
-### href(cb(href))
+### href(cb(href), filterFn(domNode)?)
 Call a callback to handle `<a href="#">` clicks.
 
 ## See Also

--- a/href.js
+++ b/href.js
@@ -6,8 +6,8 @@ module.exports = href
 // handle a click if is anchor tag with an href
 // and url lives on the same domain. Replaces
 // trailing '#' so empty links work as expected.
-// fn(str) -> null
-function href (cb) {
+// fn(str) -> fn(node)? -> null
+function href (cb, filterFn) {
   assert.equal(typeof cb, 'function', 'cb must be a function')
 
   window.onclick = function (e) {
@@ -20,6 +20,8 @@ function href (cb) {
     })(e.target)
 
     if (!node) return
+
+    if (filterFn && !filterFn(node)) return
 
     e.preventDefault()
     const href = node.href.replace(/#$/, '')


### PR DESCRIPTION
Often it is useful to filter the set of links that will be processed by the router. One common case for this is if you are linking to content inside the same domain that is not a part of your application.

This PR implements an optional filtering function that can be given to `href()` as a parameter. The function receives a DOM node and the truthiness of it's return value will be used to determine whether to call `cb` and save the url to history using `pushState` or not.

This also addresses [issue 15](https://github.com/yoshuawuyts/sheet-router/issues/15).