### PR TITLE
Ignore links with specific data attribute in href() listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ router('/multiply', 4)
 // => 8
 router('/divide', 8)
 // => 4
+
+You can ignore specific links that you do not want to process through routing by adding the `data-no-routing` attribute.
+
+```html
+  <a href="/my-external-link" data-no-routing>Non routed link</a>
+  <a href="/another-external-link" data-no-routing="true">Not routed either</a>
 ```
 
 ### virtual-dom example

--- a/href.js
+++ b/href.js
@@ -3,6 +3,8 @@ const assert = require('assert')
 
 module.exports = href
 
+const noRoutingAttrName = 'data-no-routing'
+
 // handle a click if is anchor tag with an href
 // and url lives on the same domain. Replaces
 // trailing '#' so empty links work as expected.
@@ -20,6 +22,9 @@ function href (cb) {
     })(e.target)
 
     if (!node) return
+
+    const isRoutingDisabled = node.hasAttribute(noRoutingAttrName)
+    if (isRoutingDisabled) return
 
     e.preventDefault()
     const href = node.href.replace(/#$/, '')

--- a/href.js
+++ b/href.js
@@ -13,6 +13,8 @@ function href (cb) {
   assert.equal(typeof cb, 'function', 'cb must be a function')
 
   window.onclick = function (e) {
+    if ((e.button && e.button !== 0) || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return
+
     const node = (function traverse (node) {
       if (!node) return
       if (node.localName !== 'a') return traverse(node.parentNode)


### PR DESCRIPTION
Like described in issue #15, it is sometimes necessary to create links that are not handled with the SPA router, like paths that are handled by an external 3rd party system.

This PR implements ignoring specified links by adding `data-no-routing` attribute to the `<a>` element. Because of compatibility reasons there are two ways of using this, `data-no-routing` ([boolean attribute](http://w3c.github.io/html/infrastructure.html#sec-boolean-attributes)) or `data-no-routing="true"` (string attribute, the value can be anything).