### PR TITLE
added tests and root functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ by adding the `data-no-routing` attribute.
 <a href="/another-external-link" data-no-routing="true">Not routed either</a>
 ```
 
+Also, if you pass an optional `root` node reference as a second argument to `href`, it will never intercept clicks outside that node. This is useful when your app is confined to a widget in a larger document.
+
+```js
+href(function (href) {
+  router(href)
+  console.log('link was clicked: ' + href)
+}, document.getElementById("app-root"))
+```
+
 ### qs
 Sometimes [query strings][mdn-qs] must be decoded. In order to do this, the
 `./qs.js` file is included.

--- a/href.js
+++ b/href.js
@@ -8,7 +8,7 @@ const noRoutingAttrName = 'data-no-routing'
 // handle a click if is anchor tag with an href
 // and url lives on the same domain. Replaces
 // trailing '#' so empty links work as expected.
-// fn(str) -> null
+// fn(str, obj?) -> null
 function href (cb, root) {
   assert.equal(typeof cb, 'function', 'sheet-router/href: cb must be a function')
 

--- a/href.js
+++ b/href.js
@@ -9,14 +9,14 @@ const noRoutingAttrName = 'data-no-routing'
 // and url lives on the same domain. Replaces
 // trailing '#' so empty links work as expected.
 // fn(str) -> null
-function href (cb) {
+function href (cb, root) {
   assert.equal(typeof cb, 'function', 'sheet-router/href: cb must be a function')
 
   window.onclick = function (e) {
     if ((e.button && e.button !== 0) || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return
 
     const node = (function traverse (node) {
-      if (!node) return
+      if (!node || node === root) return
       if (node.localName !== 'a') return traverse(node.parentNode)
       if (node.href === undefined) return traverse(node.parentNode)
       if (window.location.host !== node.host) return traverse(node.parentNode)

--- a/href.js
+++ b/href.js
@@ -8,7 +8,7 @@ const noRoutingAttrName = 'data-no-routing'
 // handle a click if is anchor tag with an href
 // and url lives on the same domain. Replaces
 // trailing '#' so empty links work as expected.
-// (fn(str), obj?) -> null
+// (fn(str), obj?) -> undefined
 function href (cb, root) {
   assert.equal(typeof cb, 'function', 'sheet-router/href: cb must be a function')
 

--- a/href.js
+++ b/href.js
@@ -8,7 +8,7 @@ const noRoutingAttrName = 'data-no-routing'
 // handle a click if is anchor tag with an href
 // and url lives on the same domain. Replaces
 // trailing '#' so empty links work as expected.
-// fn(str, obj?) -> null
+// (fn(str), obj?) -> null
 function href (cb, root) {
   assert.equal(typeof cb, 'function', 'sheet-router/href: cb must be a function')
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "istanbul": "^0.4.1",
     "jsdom": "^9.4.2",
     "noop2": "^2.0.0",
+    "sinon": "^1.17.5",
     "standard": "^5.4.1",
     "tape": "^4.4.0",
     "virtual-dom": "^2.1.1"

--- a/test/href.js
+++ b/test/href.js
@@ -6,6 +6,8 @@ const sinon = require('sinon')
 window.history = { pushState: sinon.spy() }
 window.location = {}
 
+const goodLink = { localName: 'a', href: 'someUrl#', hasAttribute: () => {} }
+
 const nonCatchEvents = {
   'non-links': {
     target: { localName: 'p' }
@@ -18,23 +20,23 @@ const nonCatchEvents = {
   },
   'event with ctrlKey': {
     ctrlKey: true,
-    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} }
+    target: goodLink
   },
   'event with metaKey': {
     metaKey: true,
-    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} }
+    target: goodLink
   },
   'event with altKey': {
     altKey: true,
-    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} }
+    target: goodLink
   },
   'event with shiftKey': {
     shiftKey: true,
-    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} }
+    target: goodLink
   },
   'button click': {
     button: true,
-    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} }
+    target: goodLink
   }
 }
 
@@ -46,9 +48,7 @@ tape('href', (t) => {
         localName: 'somethingOtherThanALink',
         parentNode: {
           localName: 'stillNotALink',
-          parentNode: {
-            localName: 'a', href: 'someUrl#', hasAttribute: () => {}
-          }
+          parentNode: goodLink
         }
       },
       preventDefault: sinon.spy()
@@ -88,9 +88,7 @@ tape('href', (t) => {
         localName: 'somethingOtherThanALink',
         parentNode: {
           localName: 'root',
-          parentNode: {
-            localName: 'a', href: 'someUrl#', hasAttribute: () => {}
-          }
+          parentNode: goodLink
         }
       },
       preventDefault: sinon.spy()

--- a/test/href.js
+++ b/test/href.js
@@ -8,41 +8,33 @@ window.location = {}
 
 const nonCatchEvents = {
   'non-links': {
-    target: { localName: 'p' },
-    preventDefault: sinon.spy()
+    target: { localName: 'p' }
   },
   'link without href': {
-    target: { localName: 'a', hasAttribute: () => {} },
-    preventDefault: sinon.spy()
+    target: { localName: 'a', hasAttribute: () => {} }
   },
   'link with data-no-routing': {
-    target: { localName: 'a', href: 'someUrl#', hasAttribute: (a) => a === 'data-no-routing' },
-    preventDefault: sinon.spy()
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: (a) => a === 'data-no-routing' }
   },
   'event with ctrlKey': {
     ctrlKey: true,
-    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} },
-    preventDefault: sinon.spy()
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} }
   },
   'event with metaKey': {
     metaKey: true,
-    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} },
-    preventDefault: sinon.spy()
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} }
   },
   'event with altKey': {
     altKey: true,
-    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} },
-    preventDefault: sinon.spy()
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} }
   },
   'event with shiftKey': {
     shiftKey: true,
-    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} },
-    preventDefault: sinon.spy()
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} }
   },
   'button click': {
     button: true,
-    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} },
-    preventDefault: sinon.spy()
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} }
   }
 }
 
@@ -77,6 +69,7 @@ tape('href', (t) => {
     t.test('should avoid ' + nonCatchEvent, (t) => {
       t.plan(3)
       const event = nonCatchEvents[nonCatchEvent]
+      event.preventDefault = sinon.spy()
       const previousPushCount = window.history.pushState.callCount
       const cb = sinon.spy()
       href(cb)

--- a/test/href.js
+++ b/test/href.js
@@ -1,0 +1,115 @@
+const tape = require('tape')
+const href = require('../href')
+const window = require('global/window') // will be empty object shared with href
+const sinon = require('sinon')
+
+window.history = { pushState: sinon.spy() }
+window.location = {}
+
+const nonCatchEvents = {
+  'non-links': {
+    target: { localName: 'p' },
+    preventDefault: sinon.spy()
+  },
+  'link without href': {
+    target: { localName: 'a', hasAttribute: () => {} },
+    preventDefault: sinon.spy()
+  },
+  'link with data-no-routing': {
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: (a) => a === 'data-no-routing' },
+    preventDefault: sinon.spy()
+  },
+  'event with ctrlKey': {
+    ctrlKey: true,
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} },
+    preventDefault: sinon.spy()
+  },
+  'event with metaKey': {
+    metaKey: true,
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} },
+    preventDefault: sinon.spy()
+  },
+  'event with altKey': {
+    altKey: true,
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} },
+    preventDefault: sinon.spy()
+  },
+  'event with shiftKey': {
+    shiftKey: true,
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} },
+    preventDefault: sinon.spy()
+  },
+  'button click': {
+    button: true,
+    target: { localName: 'a', href: 'someUrl#', hasAttribute: () => {} },
+    preventDefault: sinon.spy()
+  }
+}
+
+tape('href', (t) => {
+  t.test('should capture link click', (t) => {
+    t.plan(5)
+    const event = {
+      target: {
+        localName: 'somethingOtherThanALink',
+        parentNode: {
+          localName: 'stillNotALink',
+          parentNode: {
+            localName: 'a', href: 'someUrl#', hasAttribute: () => {}
+          }
+        }
+      },
+      preventDefault: sinon.spy()
+    }
+    const previousPushCount = window.history.pushState.callCount
+    const cb = sinon.spy()
+    href(cb)
+    window.onclick(event)
+
+    t.equal(event.preventDefault.callCount, 1)
+    t.equal(cb.callCount, 1)
+    t.equal(cb.lastCall.args[0], 'someUrl')
+    t.equal(window.history.pushState.callCount, previousPushCount + 1)
+    t.deepEqual(window.history.pushState.lastCall.args, [{}, null, 'someUrl'])
+  })
+
+  for (var nonCatchEvent in nonCatchEvents) {
+    t.test('should avoid ' + nonCatchEvent, (t) => {
+      t.plan(3)
+      const event = nonCatchEvents[nonCatchEvent]
+      const previousPushCount = window.history.pushState.callCount
+      const cb = sinon.spy()
+      href(cb)
+      window.onclick(event)
+
+      t.equal(event.preventDefault.callCount, 0)
+      t.equal(cb.callCount, 0)
+      t.equal(window.history.pushState.callCount, previousPushCount)
+    })
+  }
+
+  t.test('should avoid link outside provided root', (t) => {
+    t.plan(3)
+    const event = {
+      target: {
+        localName: 'somethingOtherThanALink',
+        parentNode: {
+          localName: 'root',
+          parentNode: {
+            localName: 'a', href: 'someUrl#', hasAttribute: () => {}
+          }
+        }
+      },
+      preventDefault: sinon.spy()
+    }
+    const previousPushCount = window.history.pushState.callCount
+    const cb = sinon.spy()
+    const root = event.target.parentNode
+    href(cb, root)
+    window.onclick(event)
+
+    t.equal(event.preventDefault.callCount, 0)
+    t.equal(cb.callCount, 0)
+    t.equal(window.history.pushState.callCount, previousPushCount)
+  })
+})

--- a/test/href.js
+++ b/test/href.js
@@ -19,24 +19,19 @@ const nonCatchEvents = {
     target: { localName: 'a', href: 'someUrl#', hasAttribute: (a) => a === 'data-no-routing' }
   },
   'event with ctrlKey': {
-    ctrlKey: true,
-    target: goodLink
+    ctrlKey: true
   },
   'event with metaKey': {
-    metaKey: true,
-    target: goodLink
+    metaKey: true
   },
   'event with altKey': {
-    altKey: true,
-    target: goodLink
+    altKey: true
   },
   'event with shiftKey': {
-    shiftKey: true,
-    target: goodLink
+    shiftKey: true
   },
   'button click': {
-    button: true,
-    target: goodLink
+    button: true
   }
 }
 
@@ -68,8 +63,10 @@ tape('href', (t) => {
   for (var nonCatchEvent in nonCatchEvents) {
     t.test('should avoid ' + nonCatchEvent, (t) => {
       t.plan(3)
-      const event = nonCatchEvents[nonCatchEvent]
-      event.preventDefault = sinon.spy()
+      const event = Object.assign({
+        target: goodLink,
+        preventDefault: sinon.spy()
+      }, nonCatchEvents[nonCatchEvent])
       const previousPushCount = window.history.pushState.callCount
       const cb = sinon.spy()
       href(cb)


### PR DESCRIPTION
This PR extends the signature of `href` to `href(cb, root)`, where `root` is an optional dom node that we will never capture clicks outside of.

When adding tests for this I also added missing test for the basic `href` functionality, including the data attribute thing that @jliuhtonen implemented in #27.