### PR TITLE
feat(hash): match hash routes

### DIFF
--- a/history.js
+++ b/history.js
@@ -10,6 +10,11 @@ module.exports = history
 function history (cb) {
   assert.equal(typeof cb, 'function', 'sheet-router/history: cb must be a function')
   window.onpopstate = function () {
-    cb(document.location.href)
+    cb({
+      pathname: document.location.pathname,
+      search: document.location.search,
+      href: document.location.href,
+      hash: document.location.hash
+    })
   }
 }

--- a/href.js
+++ b/href.js
@@ -29,8 +29,11 @@ function href (cb, root) {
     if (isRoutingDisabled) return
 
     e.preventDefault()
-    const href = node.href.replace(/#$/, '')
-    cb(href)
-    window.history.pushState({}, null, href)
+    cb({
+      pathname: node.pathname,
+      search: node.search,
+      href: node.href,
+      hash: node.hash
+    })
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sheet-router",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Fast, modular client router",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "license": "MIT",
   "dependencies": {
     "global": "^4.3.0",
-    "pathname-match": "^1.1.2",
     "wayfarer": "^6.2.1",
     "xtend": "^4.0.1"
   },

--- a/test/router.js
+++ b/test/router.js
@@ -39,12 +39,14 @@ test('router', (t) => {
   })
 
   t.test('should clean urls before matching', function (t) {
-    t.plan(1)
+    t.plan(2)
     const router = sheetRouter([
-      ['/foo', (params) => t.pass('called')]
+      ['/foo', (params) => t.pass('cleaned qs')],
+      ['#hello-world', (params) => t.pass('matched hash')]
     ])
 
-    router('https://foobar.com/foo#hello-world?bar=baz')
+    router('https://foobar.com/foo?bar=baz')
+    router('https://foobar.com#hello-world?bar=baz')
   })
 
   t.test('should deliver arbitrary objects', function (t) {
@@ -163,5 +165,30 @@ test('router', (t) => {
 
     router('/foo')
     router('/foo/bar')
+  })
+})
+
+test('hash routes', (t) => {
+  t.test('should allow for hash routes', (t) => {
+    t.plan(2)
+    const router = sheetRouter([
+      ['/foo', () => t.pass('foo called'), [
+        ['#bar', () => t.pass('bar called')]
+      ]]
+    ])
+
+    router('/foo')
+    router('/foo#bar')
+  })
+
+  t.test('should allow for hash partials', (t) => {
+    t.plan(1)
+    const router = sheetRouter([
+      ['/foo', () => t.pass('foo called'), [
+        ['#:bar', (params) => t.equal(params.bar, 'bar', 'params match')]
+      ]]
+    ])
+
+    router('/foo#bar')
   })
 })


### PR DESCRIPTION
- removed `pathname-match` dep
- now also matches `hash` routes by default
- should allow for jumping of hashes (fixes https://github.com/yoshuawuyts/choo/issues/65)
- now allows for defining of hashes inline