### PR TITLE
fix(pathname): fix electron regex for non index.html

### DIFF
--- a/_pathname.js
+++ b/_pathname.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-escape */
-const electron = '^(file\:|\/).*\/.*\.html?\/?'
+const electron = '^(file:\/\/|\/)(.*\.html?\/?)?'
 const protocol = '^(http(s)?(:\/\/))?(www\.)?'
 const domain = '[a-zA-Z0-9-_\.]+(:[0-9]{1,5})?(\/{1})?'
 const qs = '[\?].*$'

--- a/_pathname.js
+++ b/_pathname.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-escape */
-const electron = '^[file\:|\/].*\/index.html?(\/{1})?'
+const electron = '^(file\:|\/).*\/.*\.html?\/?'
 const protocol = '^(http(s)?(:\/\/))?(www\.)?'
 const domain = '[a-zA-Z0-9-_\.]+(:[0-9]{1,5})?(\/{1})?'
 const qs = '[\?].*$'

--- a/test/_pathname.js
+++ b/test/_pathname.js
@@ -3,11 +3,12 @@ const test = require('tape')
 const p = require('../_pathname')
 
 test('pathname', (t) => {
-  t.plan(6)
+  t.plan(7)
   t.equal(p('https://foobar.com/bin/baz#bar'), 'bin/baz/bar')
   t.equal(p('http://foobar.com/bin/baz#bar'), 'bin/baz/bar')
   t.equal(p('http://foobar.com/bin/baz#bar?beep=boop'), 'bin/baz/bar')
   t.equal(p('http://foobar.com/bin/baz#bar?beep=boop'), 'bin/baz/bar')
   t.equal(p('/Users/dat/index.html/bin/baz', true), 'bin/baz')
   t.equal(p('file:///Users/anon/src/juliangruber/dat-desktop/index.html', true), '')
+  t.equal(p('file:///Users/anon/src/juliangruber/dat-desktop/app.html', true), '')
 })

--- a/test/_pathname.js
+++ b/test/_pathname.js
@@ -3,7 +3,7 @@ const test = require('tape')
 const p = require('../_pathname')
 
 test('pathname', (t) => {
-  t.plan(7)
+  t.plan(8)
   t.equal(p('https://foobar.com/bin/baz#bar'), 'bin/baz/bar')
   t.equal(p('http://foobar.com/bin/baz#bar'), 'bin/baz/bar')
   t.equal(p('http://foobar.com/bin/baz#bar?beep=boop'), 'bin/baz/bar')
@@ -11,4 +11,5 @@ test('pathname', (t) => {
   t.equal(p('/Users/dat/index.html/bin/baz', true), 'bin/baz')
   t.equal(p('file:///Users/anon/src/juliangruber/dat-desktop/index.html', true), '')
   t.equal(p('file:///Users/anon/src/juliangruber/dat-desktop/app.html', true), '')
+  t.equal(p('file:///regular/router/path', true), '/regular/router/path')
 })


### PR DESCRIPTION
Now it applies the electron fix for all .htm(l) filenames, not just index.html.

Also fixed what appeared to be a typo in the regex.

Fixes #66