### PR TITLE
fix sheet router navigation

### DIFF
--- a/_pathname.js
+++ b/_pathname.js
@@ -16,7 +16,7 @@ module.exports = pathname
 // TODO(yw): ditch 'suffix' and allow qs routing
 // (str, bool) -> str
 function pathname (route, isElectron) {
-  if (isElectron) route = route.replace(stripElectron, '')
+  if (isElectron) route = route.replace(stripElectron, '').replace('file://', '')
   else route = route.replace(prefix, '')
   return route.replace(suffix, '').replace(normalize, '/')
 }

--- a/test/_pathname.js
+++ b/test/_pathname.js
@@ -3,11 +3,12 @@ const test = require('tape')
 const p = require('../_pathname')
 
 test('pathname', (t) => {
-  t.plan(6)
+  t.plan(7)
   t.equal(p('https://foobar.com/bin/baz#bar'), 'bin/baz/bar')
   t.equal(p('http://foobar.com/bin/baz#bar'), 'bin/baz/bar')
   t.equal(p('http://foobar.com/bin/baz#bar?beep=boop'), 'bin/baz/bar')
   t.equal(p('http://foobar.com/bin/baz#bar?beep=boop'), 'bin/baz/bar')
   t.equal(p('/Users/dat/index.html/bin/baz', true), 'bin/baz')
   t.equal(p('file:///Users/anon/src/juliangruber/dat-desktop/index.html', true), '')
+  t.equal(p('file:///preferences', true), '/preferences')
 })


### PR DESCRIPTION
This fixes routing in electron for the following types of links:

```html
<a href='/preferences'>Preferences</a>
```