### PR TITLE
also strip prefixes if on electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const pathname = require('./_pathname')
 const wayfarer = require('wayfarer')
 const assert = require('assert')
 
-const isElectron = (window.process && window.process.type)
+const isElectron = (/file:\/\//.test(window.location.origin))
 
 module.exports = sheetRouter
 


### PR DESCRIPTION
Sometimes it could be the case you're serving stuff over http on electron; we should _always_ strip the prefix hey