### PR TITLE
Fixes node crashing due to electron check

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
-const window = require('global/window')
 const pathname = require('./_pathname')
 const wayfarer = require('wayfarer')
 const assert = require('assert')
 
-const isElectron = (/file:\/\//.test(window.location.origin))
+const isElectron = require('is-electron')()
 
 module.exports = sheetRouter
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "global": "^4.3.0",
+    "is-electron": "^2.0.0",
     "wayfarer": "^6.2.1",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Accessing `window.location.origin` causes node to crash since `window.location` is undefined in node.

Using [is-electron](https://github.com/cheton/is-electron) which performs a safer check resolves this.