### PR TITLE
Replace const with var

### DIFF
--- a/_pathname.js
+++ b/_pathname.js
@@ -1,14 +1,14 @@
 /* eslint-disable no-useless-escape */
-const electron = '^(file:\/\/|\/)(.*\.html?\/?)?'
-const protocol = '^(http(s)?(:\/\/))?(www\.)?'
-const domain = '[a-zA-Z0-9-_\.]+(:[0-9]{1,5})?(\/{1})?'
-const qs = '[\?].*$'
+var electron = '^(file:\/\/|\/)(.*\.html?\/?)?'
+var protocol = '^(http(s)?(:\/\/))?(www\.)?'
+var domain = '[a-zA-Z0-9-_\.]+(:[0-9]{1,5})?(\/{1})?'
+var qs = '[\?].*$'
 /* eslint-enable no-useless-escape */
 
-const stripElectron = new RegExp(electron)
-const prefix = new RegExp(protocol + domain)
-const normalize = new RegExp('#')
-const suffix = new RegExp(qs)
+var stripElectron = new RegExp(electron)
+var prefix = new RegExp(protocol + domain)
+var normalize = new RegExp('#')
+var suffix = new RegExp(qs)
 
 module.exports = pathname
 

--- a/create-location.js
+++ b/create-location.js
@@ -1,8 +1,8 @@
-const document = require('global/document')
-const assert = require('assert')
-const xtend = require('xtend')
+var document = require('global/document')
+var assert = require('assert')
+var xtend = require('xtend')
 
-const qs = require('./qs')
+var qs = require('./qs')
 
 module.exports = createLocation
 
@@ -17,29 +17,26 @@ module.exports = createLocation
 // (obj?, str?) -> obj
 function createLocation (state, patch) {
   if (!state) {
-    const newLocation = {
+    return {
       pathname: document.location.pathname,
       search: (document.location.search) ? qs(document.location.search) : {},
       hash: document.location.hash,
       href: document.location.href
     }
-    return newLocation
   } else {
     assert.equal(typeof state, 'object', 'sheet-router/create-location: state should be an object')
     if (typeof patch === 'string') {
-      const newLocation = parseUrl(patch)
-      return newLocation
+      return parseUrl(patch)
     } else {
       assert.equal(typeof patch, 'object', 'sheet-router/create-location: patch should be an object')
-      const newLocation = xtend(state, patch)
-      return newLocation
+      return xtend(state, patch)
     }
   }
 
   // parse a URL into a kv object inside the browser
   // str -> obj
   function parseUrl (url) {
-    const a = document.createElement('a')
+    var a = document.createElement('a')
     a.href = url
 
     return {

--- a/hash.js
+++ b/hash.js
@@ -1,5 +1,5 @@
-const window = require('global/window')
-const assert = require('assert')
+var window = require('global/window')
+var assert = require('assert')
 
 module.exports = hash
 

--- a/history.js
+++ b/history.js
@@ -1,6 +1,6 @@
-const document = require('global/document')
-const window = require('global/window')
-const assert = require('assert')
+var document = require('global/document')
+var window = require('global/window')
+var assert = require('assert')
 
 module.exports = history
 

--- a/href.js
+++ b/href.js
@@ -1,11 +1,11 @@
-const window = require('global/window')
-const assert = require('assert')
+var window = require('global/window')
+var assert = require('assert')
 
-const qs = require('./qs')
+var qs = require('./qs')
 
 module.exports = href
 
-const noRoutingAttrName = 'data-no-routing'
+var noRoutingAttrName = 'data-no-routing'
 
 // handle a click if is anchor tag with an href
 // and url lives on the same domain. Replaces
@@ -17,7 +17,7 @@ function href (cb, root) {
   window.onclick = function (e) {
     if ((e.button && e.button !== 0) || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return
 
-    const node = (function traverse (node) {
+    var node = (function traverse (node) {
       if (!node || node === root) return
       if (node.localName !== 'a') return traverse(node.parentNode)
       if (node.href === undefined) return traverse(node.parentNode)
@@ -27,7 +27,7 @@ function href (cb, root) {
 
     if (!node) return
 
-    const isRoutingDisabled = node.hasAttribute(noRoutingAttrName)
+    var isRoutingDisabled = node.hasAttribute(noRoutingAttrName)
     if (isRoutingDisabled) return
 
     e.preventDefault()

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-const pathname = require('./_pathname')
-const wayfarer = require('wayfarer')
-const assert = require('assert')
+var pathname = require('./_pathname')
+var wayfarer = require('wayfarer')
+var assert = require('assert')
 
-const isElectron = require('is-electron')()
+var isElectron = require('is-electron')()
 
 module.exports = sheetRouter
 
@@ -17,10 +17,10 @@ function sheetRouter (opts, tree) {
   assert.equal(typeof opts, 'object', 'sheet-router: opts must be a object')
   assert.ok(Array.isArray(tree), 'sheet-router: tree must be an array')
 
-  const dft = opts.default || '/404'
+  var dft = opts.default || '/404'
   assert.equal(typeof dft, 'string', 'sheet-router: dft must be a string')
 
-  const router = wayfarer(dft)
+  var router = wayfarer(dft)
   var prevCallback = null
   var prevRoute = null
 
@@ -40,8 +40,8 @@ function sheetRouter (opts, tree) {
       var rootArr = tree[0]
     }
 
-    const cb = (typeof tree[1] === 'function') ? tree[1] : null
-    const children = (Array.isArray(tree[1]))
+    var cb = (typeof tree[1] === 'function') ? tree[1] : null
+    var children = (Array.isArray(tree[1]))
       ? tree[1]
       : Array.isArray(tree[2]) ? tree[2] : null
 
@@ -52,12 +52,12 @@ function sheetRouter (opts, tree) {
     }
 
     if (cb) {
-      const innerRoute = route
+      var innerRoute = route
         ? fullRoute.concat(route).join('/')
         : fullRoute.length ? fullRoute.join('/') : route
 
       // if opts.thunk is false or only enabled for match, don't thunk
-      const handler = (opts.thunk === false || opts.thunk === 'match')
+      var handler = (opts.thunk === false || opts.thunk === 'match')
         ? cb
         : thunkify(cb)
       router.on(innerRoute, handler)

--- a/qs.js
+++ b/qs.js
@@ -1,13 +1,13 @@
-const window = require('global/window')
+var window = require('global/window')
 
-const decodeURIComponent = window.decodeURIComponent
-const reg = new RegExp('([^?=&]+)(=([^&]*))?', 'g')
+var decodeURIComponent = window.decodeURIComponent
+var reg = new RegExp('([^?=&]+)(=([^&]*))?', 'g')
 
 module.exports = qs
 
 // decode a uri into a kv representation :: str -> obj
 function qs (uri) {
-  const obj = {}
+  var obj = {}
   uri.replace(/^.*\?/, '').replace(reg, map)
   return obj
 


### PR DESCRIPTION
Switch out uses of the const keyword with var for compatibility with older browsers. Fixes #78.