### PR TITLE
fix electron detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ var pathname = require('./_pathname')
 var wayfarer = require('wayfarer')
 var assert = require('assert')
 
-var isElectron = require('is-electron')()
+var isLocalFile = (/file:\/\//.test(typeof window === 'object' &&
+  window.location && window.location.origin)) // electron support
 
 module.exports = sheetRouter
 
@@ -82,11 +83,11 @@ function sheetRouter (opts, tree) {
     assert.equal(typeof route, 'string', 'sheet-router: route must be a string')
 
     if (opts.thunk === false) {
-      return router(pathname(route, isElectron), arg1, arg2, arg3, arg4, arg5)
+      return router(pathname(route, isLocalFile), arg1, arg2, arg3, arg4, arg5)
     } else if (route === prevRoute) {
       return prevCallback(arg1, arg2, arg3, arg4, arg5)
     } else {
-      prevRoute = pathname(route, isElectron)
+      prevRoute = pathname(route, isLocalFile)
       prevCallback = router(prevRoute)
       return prevCallback(arg1, arg2, arg3, arg4, arg5)
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "license": "MIT",
   "dependencies": {
     "global": "^4.3.0",
-    "is-electron": "^2.0.0",
     "wayfarer": "^6.2.1",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Fixes regression introduced in https://github.com/yoshuawuyts/sheet-router/pull/77 - wasn't actually checking if we're inside electron but more if we were reading from a file on disk hah. This patch fixes that while still ensuring it all works inside node :sparkles: