### PR TITLE
Fix IE href capturing (#82)

### DIFF
--- a/href.js
+++ b/href.js
@@ -21,7 +21,7 @@ function href (cb, root) {
       if (!node || node === root) return
       if (node.localName !== 'a') return traverse(node.parentNode)
       if (node.href === undefined) return traverse(node.parentNode)
-      if (window.location.host !== node.host) return traverse(node.parentNode)
+      if (!sameOrigin(node.href)) return
       return node
     })(e.target)
 
@@ -38,4 +38,11 @@ function href (cb, root) {
       hash: node.hash
     })
   }
+}
+
+function sameOrigin (href) {
+  var location = window.location
+  var origin = location.protocol + '//' + location.hostname
+  if (location.port) origin += ':' + location.port
+  return (href && (href.indexOf(origin) === 0))
 }

--- a/test/href.js
+++ b/test/href.js
@@ -4,9 +4,19 @@ const window = require('global/window') // will be empty object shared with href
 const sinon = require('sinon')
 
 window.history = { pushState: sinon.spy() }
-window.location = {}
+window.location = {
+  'href': 'https://example.com/',
+  'origin': 'https://example.com',
+  'protocol': 'https:',
+  'host': 'example.com',
+  'hostname': 'example.com',
+  'port': '',
+  'pathname': '/',
+  'search': '',
+  'hash': ''
+}
 
-const goodLink = { localName: 'a', href: 'someUrl#', pathname: 'someUrl', hasAttribute: () => {} }
+const goodLink = { localName: 'a', href: 'https://example.com/someUrl#', pathname: 'someUrl', hasAttribute: () => {} }
 
 const nonCatchEvents = {
   'non-links': {
@@ -55,7 +65,7 @@ tape('href', (t) => {
     t.equal(event.preventDefault.callCount, 1)
     t.equal(cb.callCount, 1)
     t.deepEqual(cb.lastCall.args[0], {
-      hash: undefined, href: 'someUrl#', pathname: 'someUrl', search: {}
+      hash: undefined, href: 'https://example.com/someUrl#', pathname: 'someUrl', search: {}
     })
   })
 
@@ -87,6 +97,24 @@ tape('href', (t) => {
           parentNode: goodLink
         }
       },
+      preventDefault: sinon.spy()
+    }
+    const previousPushCount = window.history.pushState.callCount
+    const cb = sinon.spy()
+    const root = event.target.parentNode
+    href(cb, root)
+    window.onclick(event)
+
+    t.equal(event.preventDefault.callCount, 0)
+    t.equal(cb.callCount, 0)
+    t.equal(window.history.pushState.callCount, previousPushCount)
+  })
+
+  t.test('should avoid other host', (t) => {
+    t.plan(3)
+    const event = {
+      // href is a different origin because it is another protocol
+      target: { localName: 'a', href: 'http://example.com', hasAttribute: () => {} },
       preventDefault: sinon.spy()
     }
     const previousPushCount = window.history.pushState.callCount


### PR DESCRIPTION
This PR replaces the same origin check with the one borrowed from [page.js](https://github.com/visionmedia/page.js/blob/500fff73383135615db89eedb29944f6441ad023/index.js#L616-L620).

I haven't tested it in IE, I just refactored the code and added tests.